### PR TITLE
Add navigation delegate when initializing the the WebView.

### DIFF
--- a/WherebyWebViewDemo-iOS/WebViewController.swift
+++ b/WherebyWebViewDemo-iOS/WebViewController.swift
@@ -8,7 +8,7 @@
 import UIKit
 import WebKit
 
-class WebViewController: UIViewController {
+class WebViewController: UIViewController, WKNavigationDelegate {
     
     internal var url: URL!
     
@@ -34,6 +34,7 @@ class WebViewController: UIViewController {
         // Initialize the WKWebView with the custom configuration and delegate:
         webView = WKWebView(frame: .zero, configuration: config)
         webView.uiDelegate = self
+        webView.navigationDelegate = self
         
         // Add the webView to the view hierarchy:
         view.addSubview(webView)


### PR DESCRIPTION
Add navigation delegate to the webview to allow downloading shared files. 

Tested as: 
1. From the main branch, run the demo app. Join the room from another client and share a file. Confirm that the iOS demo app client is not able to download the shared file. 
2. Run the app from the current branch and confirm that the download is now fixed. 